### PR TITLE
Refactor TypeRacer script

### DIFF
--- a/FastTypeRacer/TypeRacer.py
+++ b/FastTypeRacer/TypeRacer.py
@@ -1,40 +1,46 @@
-from selenium import webdriver
-from selenium.webdriver.support.ui import Select
-from selenium.webdriver.common.keys import Keys
-from selenium.webdriver.common.by import By
-from selenium.webdriver.support import expected_conditions as EC
-from selenium.webdriver.support.ui import WebDriverWait
 import time
-import datetime
 
-from bs4 import BeautifulSoup
-import urllib
+_PYAUTOGUI_IMPORT_ERROR = None
+try:
+    from pyautogui import typewrite
+except Exception as exc:  # pragma: no cover - environment specific
+    typewrite = None
+    _PYAUTOGUI_IMPORT_ERROR = exc
 
-from pyautogui import press, typewrite, hotkey
 
 def TypeRacerFill():
-	baselink = "https://play.typeracer.com/"
-	driver = webdriver.Chrome(executable_path="chromedriver.exe")
-	driver.get(baselink)
-	driver.implicitly_wait(5)
-	enterRaceButton = driver.find_element_by_link_text("Practice").click()
-	print("[2] Retrieving text ...")
-	span = driver.find_elements_by_xpath("//span[@unselectable='on']")
-	if len(span) == 2:
-		full_text = span[0].text + " " + span[1].text
-	else:
-		full_text = span[0].text + span[1].text + " "+ span[2].text
-	print(full_text)
-	print("[3] Waiting for countdown ...4")
-	time.sleep(1)
-	print("[3] Waiting for countdown ...3")
-	time.sleep(1)
-	print("[3] Waiting for countdown ...2")
-	time.sleep(1)
-	print("[3] Waiting for countdown ...1")
-	time.sleep(1)
-	print("getting element by class name")
+    try:
+        from selenium import webdriver
+        from selenium.webdriver.common.by import By
+    except ImportError as exc:  # pragma: no cover - environment specific
+        raise ImportError(
+            "selenium is required to run this script. Install it with 'pip install selenium'."
+        ) from exc
 
-	typewrite(full_text, interval=0.05)
+    if typewrite is None:
+        raise ImportError(
+            "pyautogui is required to run this script. Install it with 'pip install pyautogui'."
+        ) from _PYAUTOGUI_IMPORT_ERROR
 
-TypeRacerFill()
+    baselink = "https://play.typeracer.com/"
+    driver = webdriver.Chrome()
+    driver.get(baselink)
+    driver.implicitly_wait(5)
+    driver.find_element(By.LINK_TEXT, "Practice").click()
+    print("[2] Retrieving text ...")
+    span = driver.find_elements(By.XPATH, "//span[@unselectable='on']")
+    if len(span) == 2:
+        full_text = span[0].text + " " + span[1].text
+    else:
+        full_text = span[0].text + span[1].text + " " + span[2].text
+    print(full_text)
+    for i in range(4, 0, -1):
+        print(f"[3] Waiting for countdown ...{i}")
+        time.sleep(1)
+
+    typewrite(full_text, interval=0.05)
+    driver.quit()
+
+
+if __name__ == "__main__":
+    TypeRacerFill()


### PR DESCRIPTION
## Summary
- handle optional pyautogui import so module loads without a display
- modernize selenium usage and clean up countdown logic

## Testing
- `python -m py_compile FastTypeRacer/TypeRacer.py`
- `python FastTypeRacer/TypeRacer.py` *(fails: pyautogui requires an X11 display)*

------
https://chatgpt.com/codex/tasks/task_e_688f3ecf94b483239606a3e2caa45065